### PR TITLE
Refactor dependencies structure

### DIFF
--- a/.changeset/refactor-dependencies.md
+++ b/.changeset/refactor-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@grancalavera/bridge": minor
+---
+
+Move dependencies to devDependencies except comlink, make rxjs a peer dependency, remove lodash

--- a/.changeset/refactor-dependencies.md
+++ b/.changeset/refactor-dependencies.md
@@ -1,5 +1,0 @@
----
-"@grancalavera/bridge": minor
----
-
-Move dependencies to devDependencies except comlink, make rxjs a peer dependency, remove lodash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @grancalavera/bridge
 
+## 0.3.0
+
+### Minor Changes
+
+- 151b6e5: Move dependencies to devDependencies except comlink, make rxjs a peer dependency, remove lodash
+
 ## 0.2.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,35 @@
 {
   "name": "@grancalavera/bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grancalavera/bridge",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@react-rxjs/core": "^0.10.7",
-        "comlink": "4.4.2",
-        "lodash": "4.17.21",
-        "react": "19.1.1",
-        "react-dom": "19.1.1",
-        "react-rxjs": "2.0.8",
-        "rxjs": "7.8.2"
+        "comlink": "4.4.2"
       },
       "devDependencies": {
         "@changesets/cli": "^2.29.7",
-        "@types/lodash": "4.17.20",
+        "@react-rxjs/core": "^0.10.7",
         "@types/node": "^24.6.0",
         "@types/react": "19.1.10",
         "@types/react-dom": "19.1.7",
         "@vitejs/plugin-react-swc": "4.0.0",
         "@vitest/browser": "^3.2.4",
         "happy-dom": "^19.0.2",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "react-rxjs": "2.0.8",
+        "rxjs": "7.8.2",
         "tsdown": "^0.15.6",
         "typescript": "5.8.3",
         "vite": "7.1.2",
         "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1060,6 +1061,7 @@
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/@react-rxjs/core/-/core-0.10.7.tgz",
       "integrity": "sha512-dornp8pUs9OcdqFKKRh9+I2FVe21gWufNun6RYU1ddts7kUy9i4Thvl0iqcPFbGY61cJQMAJF7dxixWMSD/A/A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rx-state/core": "0.1.4",
@@ -1627,6 +1629,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@rx-state/core/-/core-0.1.4.tgz",
       "integrity": "sha512-Z+3hjU2xh1HisLxt+W5hlYX/eGSDaXXP+ns82gq/PLZpkXLu0uwcNUh9RLY3Clq4zT+hSsA3vcpIGt6+UAb8rQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "rxjs": ">=7"
@@ -1931,13 +1934,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2968,12 +2964,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -3349,6 +3339,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3358,6 +3349,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
@@ -3377,6 +3369,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/react-rxjs/-/react-rxjs-2.0.8.tgz",
       "integrity": "sha512-/LbKpFwRqHMoOPucnr1fG1Sdv5kH7elq59e+H4kryNCvXQiZkynH5PzyxAZO000ZPpQQkqeJwnBXjoql56gV7w==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/read-yaml-file": {
@@ -3596,6 +3589,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -3612,6 +3606,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3947,6 +3942,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {
@@ -4000,6 +3996,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grancalavera/bridge",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -34,23 +34,24 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@react-rxjs/core": "^0.10.7",
-    "comlink": "4.4.2",
-    "lodash": "4.17.21",
-    "react": "19.1.1",
-    "react-dom": "19.1.1",
-    "react-rxjs": "2.0.8",
-    "rxjs": "7.8.2"
+    "comlink": "4.4.2"
+  },
+  "peerDependencies": {
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
-    "@types/lodash": "4.17.20",
+    "@react-rxjs/core": "^0.10.7",
     "@types/node": "^24.6.0",
     "@types/react": "19.1.10",
     "@types/react-dom": "19.1.7",
     "@vitejs/plugin-react-swc": "4.0.0",
     "@vitest/browser": "^3.2.4",
     "happy-dom": "^19.0.2",
+    "react": "19.1.1",
+    "react-dom": "19.1.1",
+    "react-rxjs": "2.0.8",
+    "rxjs": "7.8.2",
     "tsdown": "^0.15.6",
     "typescript": "5.8.3",
     "vite": "7.1.2",


### PR DESCRIPTION
## Summary
- Moved all dependencies to devDependencies except comlink (the only runtime dependency)
- Made rxjs a peer dependency to avoid version conflicts in consuming applications
- Removed lodash from all dependencies (not used in codebase)