### PR TITLE
Replace Query/Mutation with unified Operation type

### DIFF
--- a/.changeset/replace-query-mutation-with-operation.md
+++ b/.changeset/replace-query-mutation-with-operation.md
@@ -1,0 +1,5 @@
+---
+"@grancalavera/bridge": minor
+---
+
+Replace `Query` and `Mutation` types with unified `Operation` type. Both types were structurally identical (`(input?) => Promise<Response>`), so they have been merged into a single `Operation<Response, Input>` type. This is a breaking change: update imports from `Query`/`Mutation` to `Operation`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,28 @@ Bridge is a library to simplify communication and state sharing between differen
 - `npm run test:watch` - Run tests in watch mode
 - Tests should run automatically before publishing the package
 
+## Smoke Testing Examples
+
+After making changes to the library, smoke test the examples with the dev server (`npm run dev`) and a browser:
+
+1. **Echo Example** (`/examples/echo/`)
+   - Click "Send Echo" — verify a response appears with a client ID and message
+   - Click "Subscribe" — verify "Waiting for messages..." appears
+   - Click "Send Echo" again — verify the subscription receives the message
+   - Open a **second tab** to `/examples/echo/`
+   - In tab 2, click "Send Echo" — switch to tab 1 and verify the subscription received the cross-tab message
+
+2. **User Profile Example** (`/examples/user-profile/`)
+   - Click "Get User 1" — verify user details (name, email, age) appear
+   - Click "Watch User 1" — verify the watch section appears with user data
+   - Select "User 1" in the update dropdown, fill in a new name, click "Update User" — verify the watch section updates
+   - Open a **second tab** to `/examples/user-profile/`
+   - In tab 1, click "Watch User 1"
+   - In tab 2, select User 1, update the name, click "Update User"
+   - Switch to tab 1 — verify the watch section shows the name updated from tab 2
+
+The multi-tab tests verify SharedWorker communication across browsing contexts.
+
 ## Git Best Practices
 
 - **Force Pushing**: Never use `git push --force`. Always use `git push --force-with-lease` instead, which prevents accidentally overwriting commits that others have pushed to the remote branch.

--- a/examples/echo/src/contract.ts
+++ b/examples/echo/src/contract.ts
@@ -1,6 +1,6 @@
-import type { Contract, Mutation, Subscription } from "../../../src/model";
+import type { Contract, Operation, Subscription } from "../../../src/model";
 
 export type EchoContract = Contract<{
-  echo: Mutation<string, string>;
+  echo: Operation<string, string>;
   subscribeEcho: Subscription<string, { timestamp?: boolean }>;
 }>;

--- a/examples/user-profile/src/contract.ts
+++ b/examples/user-profile/src/contract.ts
@@ -1,9 +1,4 @@
-import type {
-  Contract,
-  Query,
-  Mutation,
-  Subscription,
-} from "../../../src/model";
+import type { Contract, Operation, Subscription } from "../../../src/model";
 
 export type UserId = number | string;
 
@@ -15,7 +10,7 @@ export type User = {
 };
 
 export type UserProfileContract = Contract<{
-  getUser: Query<User, UserId>;
-  updateUser: Mutation<User, { userId: UserId; updates: Partial<User> }>;
+  getUser: Operation<User, UserId>;
+  updateUser: Operation<User, { userId: UserId; updates: Partial<User> }>;
   watchUser: Subscription<User, UserId>;
 }>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grancalavera/bridge",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grancalavera/bridge",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "dependencies": {
         "comlink": "4.4.2",
         "rxjs": "7.8.2"
@@ -71,6 +71,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2489,6 +2490,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2579,6 +2581,7 @@
       "integrity": "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -2589,6 +2592,7 @@
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2656,6 +2660,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -2878,6 +2883,7 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -3029,6 +3035,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3410,6 +3417,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4193,6 +4201,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5718,6 +5727,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6350,6 +6360,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6520,6 +6531,7 @@
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6831,6 +6843,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -7625,6 +7638,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7742,6 +7756,7 @@
       "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -7840,6 +7855,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -8104,6 +8120,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,5 +1,5 @@
-import type { Contract, Mutation } from "./model";
+import type { Contract, Operation } from "./model";
 
 export type RegistryContract = Contract<{
-  registerClient: Mutation;
+  registerClient: Operation;
 }>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,9 @@ export { createSharedWorkerRuntime } from "./runtime.ts";
 export { wrapWorkerPort, subscriptions } from "./model.ts";
 export type {
   Contract,
-  Mutation,
+  Operation,
   Operations,
   ProxyMarkedFunction,
-  Query,
   Subscription,
   SubscriptionInput,
   SubscriptionKey,

--- a/src/model.test-d.ts
+++ b/src/model.test-d.ts
@@ -2,40 +2,35 @@ import * as Comlink from "comlink";
 import { describe, expectTypeOf, test } from "vitest";
 import {
   Contract,
-  Mutation,
+  Operation,
   ProxyMarkedFunction,
-  Query,
   Subscription,
 } from "./model";
 import { createWorker } from "./worker";
 
 type TheContract = Contract<{
-  queryWithoutInput: Query<string, void>;
-  queryWithInput: Query<string, string>;
-  mutationWithoutInput: Mutation<string, void>;
-  mutationWithInput: Mutation<string, string>;
+  operationWithoutInput: Operation<string, void>;
+  operationWithInput: Operation<string, string>;
   subscriptionWithoutInput: Subscription<string, void>;
   subscriptionWithInput: Subscription<string, string>;
 }>;
 
 const worker = createWorker<TheContract>(() => ({
-  queryWithoutInput: async () => "",
-  queryWithInput: async (input: string) => input,
-  mutationWithoutInput: async () => "",
-  mutationWithInput: async (input: string) => input,
+  operationWithoutInput: async () => "",
+  operationWithInput: async (input: string) => input,
   subscriptionWithoutInput: async () => Comlink.proxy(() => {}),
   subscriptionWithInput: async () => Comlink.proxy(() => {}),
 }));
 
-describe("query", () => {
+describe("operation", () => {
   test("without input should return a promise of string", () => {
-    expectTypeOf(worker.queryWithoutInput).returns.toEqualTypeOf<
+    expectTypeOf(worker.operationWithoutInput).returns.toEqualTypeOf<
       Promise<string>
     >();
   });
 
   test("with input should return a promise of string", () => {
-    expectTypeOf(worker.queryWithInput).returns.toEqualTypeOf<
+    expectTypeOf(worker.operationWithInput).returns.toEqualTypeOf<
       Promise<string>
     >();
   });
@@ -47,40 +42,9 @@ describe("query", () => {
       string,
     ];
 
-    expectTypeOf(worker.queryWithInput).parameters.toEqualTypeOf<Expected>();
-  });
-
-  test("should not take an input parameter at the last positional argument", () => {
-    type Expected = [
-      // the first argument is always the clientId
-      string,
-    ];
-
-    expectTypeOf(worker.queryWithoutInput).parameters.toEqualTypeOf<Expected>();
-  });
-});
-
-describe("mutation", () => {
-  test("without input should return a promise of string", () => {
-    expectTypeOf(worker.mutationWithoutInput).returns.toEqualTypeOf<
-      Promise<string>
-    >();
-  });
-
-  test("with input should return a promise of string", () => {
-    expectTypeOf(worker.mutationWithInput).returns.toEqualTypeOf<
-      Promise<string>
-    >();
-  });
-
-  test("should take an input parameter at the last positional argument", () => {
-    type Expected = [
-      // the first argument is always the clientId
-      string,
-      string,
-    ];
-
-    expectTypeOf(worker.mutationWithInput).parameters.toEqualTypeOf<Expected>();
+    expectTypeOf(
+      worker.operationWithInput,
+    ).parameters.toEqualTypeOf<Expected>();
   });
 
   test("should not take an input parameter at the last positional argument", () => {
@@ -90,7 +54,7 @@ describe("mutation", () => {
     ];
 
     expectTypeOf(
-      worker.mutationWithoutInput,
+      worker.operationWithoutInput,
     ).parameters.toEqualTypeOf<Expected>();
   });
 });

--- a/src/model.ts
+++ b/src/model.ts
@@ -59,21 +59,10 @@ export type ProxyMarkedFunction<
 > = T & Comlink.ProxyMarked;
 
 /**
- * Represents a query operation that retrieves data.
- * Returns a Promise of the response data.
+ * Represents an operation that takes an optional input and returns a Promise of the response.
+ * Use this for both queries (data retrieval) and mutations (data modification).
  */
-export type Query<
-  Response extends StructuredCloneable = void,
-  Input extends StructuredCloneable = void,
-> = [Input] extends [void]
-  ? () => Promise<Response>
-  : (input: Input) => Promise<Response>;
-
-/**
- * Represents a mutation operation that modifies data.
- * Returns a Promise of the operation result.
- */
-export type Mutation<
+export type Operation<
   Response extends StructuredCloneable = void,
   Input extends StructuredCloneable = void,
 > = [Input] extends [void]
@@ -102,8 +91,7 @@ export type Subscription<
     ) => Promise<() => void>;
 
 /**
- * A collection of operations (queries, mutations, and subscriptions)
- * mapped by their operation names.
+ * A collection of operations and subscriptions mapped by their operation names.
  */
 export type Operations = Record<
   string,
@@ -195,8 +183,8 @@ export const wrapWorkerPort = <T extends Operations>(port: MessagePort) =>
  * Example:
  * ```typescript
  * interface MyOperations {
- *   getData: Query<void, string>;
- *   updateData: Mutation<string, void>;
+ *   getData: Operation<string, void>;
+ *   updateData: Operation<void, string>;
  *   watchChanges: Subscription<void, number>;
  * }
  *

--- a/tests/integration/sharedworker-communication.test.ts
+++ b/tests/integration/sharedworker-communication.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import type { Contract, Mutation, Subscription } from "../../dist/index.js";
+import type { Contract, Operation, Subscription } from "../../dist/index.js";
 
 type TestContract = Contract<{
-  echo: Mutation<string, string>;
+  echo: Operation<string, string>;
   subscribeEcho: Subscription<string, { timestamp?: boolean }>;
 }>;
 


### PR DESCRIPTION
## Summary

- Merged `Query` and `Mutation` into a single `Operation<Response, Input>` type — they were structurally identical
- Updated all consumers: library core, examples, and integration tests
- Added smoke testing guide to CLAUDE.md

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 20 tests pass
- [x] `npm run build` succeeds
- [x] Echo example: single-tab and multi-tab smoke test
- [x] User Profile example: single-tab and multi-tab smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)