### PR TITLE
Replace subscription callbacks with materialized observables

### DIFF
--- a/.changeset/materialized-subscriptions.md
+++ b/.changeset/materialized-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"@grancalavera/bridge": minor
+---
+
+Replace subscription callbacks with materialized observables. Subscriptions now use a single `onNotification` callback receiving RxJS `ObservableNotification<T>` instead of separate `onNext`, `onError`, and `onComplete` callbacks. This is a breaking change for custom `WorkerFactory` implementations that use the `subscribe` helper from `WorkerContext`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Lint, Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Build library
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/examples/echo/src/worker.ts
+++ b/examples/echo/src/worker.ts
@@ -16,14 +16,12 @@ export const echoWorker = createWorker<EchoContract>(({ subscribe }) => {
       echo$.next(message);
       return message;
     },
-    async subscribeEcho(clientId, onNext, onError, onComplete, input) {
+    async subscribeEcho(clientId, onNotification, input) {
       const timestamp = input?.timestamp;
       return subscribe(
         timestamp ? echoWithTimestamp$ : echo$,
         clientId,
-        onNext,
-        onError,
-        onComplete,
+        onNotification,
       );
     },
   };

--- a/examples/user-profile/src/worker.ts
+++ b/examples/user-profile/src/worker.ts
@@ -70,13 +70,7 @@ export const userProfileWorker = createWorker<UserProfileContract>(
         return updatedUser;
       },
 
-      async watchUser(
-        clientId: string,
-        onNext: (value: User) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
-        userId: UserId,
-      ) {
+      async watchUser(clientId, onNotification, userId) {
         console.log(`[${clientId}] watchUser called with userId: ${userId}`);
         const user$ = getOrCreateUser(userId);
         const observable$ = user$.pipe(
@@ -86,7 +80,7 @@ export const userProfileWorker = createWorker<UserProfileContract>(
           })),
           share(),
         );
-        return subscribe(observable$, clientId, onNext, onError, onComplete);
+        return subscribe(observable$, clientId, onNotification);
       },
     };
   },

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,66 @@
+# Internals
+
+How `createWorkerFactory`, `registryWorkerFactory`, and `createWorker` compose to produce a SharedWorker, and how `createClient` connects from a browser tab.
+
+```mermaid
+sequenceDiagram
+    participant Tab as Browser Tab
+    participant CC as createClient
+    participant Lock as navigator.locks
+    participant SW as SharedWorker
+    participant CW as createWorker
+    participant CWF as createWorkerFactory
+    participant CM as clients Map
+    participant RF as registryWorkerFactory
+    participant UF as userFactory
+
+    note over CW, UF: Worker Setup
+    CW ->> CWF: createWorkerFactory()
+    CWF ->> CM: create shared Map<string, ClientRep>
+    CW ->> CWF: invoke with userFactory
+    CWF ->> UF: userFactory({ subscribe, clients })
+    UF -->> CWF: user operations
+    CW ->> CWF: invoke with registryWorkerFactory
+    CWF ->> RF: registryWorkerFactory({ subscribe, clients })
+    RF -->> CWF: { registerClient }
+    CWF -->> CW: { ...userOps, ...registerClient }
+    CW ->> SW: expose merged worker object
+
+    note over Tab, SW: Client Connection
+    Tab ->> CC: createClient({ sharedWorker })
+    CC ->> CC: clientId = crypto.randomUUID()
+    CC ->> Lock: navigator.locks.request(clientId)
+    Lock ->> SW: proxy.registerClient(clientId)
+    SW ->> RF: registerClient(clientId)
+    RF ->> CM: clients.set(clientId, new ClientRep)
+    RF -->> Lock: resolved
+    note over Lock: lock held for tab lifetime
+    CC -->> Tab: [clientProxy, subscriptions]
+
+    note over Tab, CM: Usage
+    Tab ->> SW: client.someOperation(...args)
+    note right of Tab: proxy auto-prepends clientId
+    SW ->> SW: someOperation(clientId, ...args)
+    SW -->> Tab: result
+
+    note over Tab, CM: Subscription
+    Tab ->> SW: subscriptions("watchSomething", input)
+    SW ->> CM: track subscription in ClientRep
+    SW --) Tab: onNotification (stream of updates)
+
+    note over Tab, CM: Cleanup (tab closes)
+    Tab -x Lock: tab closed, lock released
+    Lock ->> RF: lock released callback fires
+    RF ->> CM: client.subscriptions.unsubscribe()
+    RF ->> CM: clients.delete(clientId)
+```
+
+## Lifecycle
+
+1. **Worker setup** -- `createWorker` calls `createWorkerFactory()`, which allocates a single shared `clients` map. It then invokes both the user-provided factory and `registryWorkerFactory` with the same `WorkerContext` (`{ subscribe, clients }`), merging their results into one worker object.
+
+2. **Client connection** -- `createClient` generates a `clientId`, acquires a `navigator.locks` Web Lock for that id, and calls `registerClient` on the worker. The worker adds the client to the shared map. The lock is held for the lifetime of the tab.
+
+3. **Usage** -- The returned client proxy intercepts every call and auto-prepends `clientId`, so worker operations always know which client is calling. Subscriptions are tracked per-client via `ClientRep.subscriptions`.
+
+4. **Cleanup** -- When a tab closes (or navigates away), the browser releases the Web Lock. The worker detects this, unsubscribes all of that client's subscriptions, and removes the client from the map.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,13 +1,63 @@
 import * as Comlink from "comlink";
-import type { ObservableNotification, Observable } from "rxjs";
+import { Observable, Subject, type ObservableNotification } from "rxjs";
+import { dematerialize } from "rxjs/operators";
 import type { RegistryContract } from "./contract";
-import {
-  subscriptions,
-  wrapWorkerPort,
-  type Operations,
-  type SubscriptionKey,
-  type SubscriptionInput,
+import type {
+  Operations,
+  SubscriptionInput,
+  SubscriptionKey,
+  WorkerContract,
 } from "./model";
+
+/**
+ * Creates a Comlink remote proxy for the given worker contract using the provided MessagePort.
+ * @param port The MessagePort to communicate with the worker.
+ * @returns A Comlink remote proxy for the worker contract.
+ */
+export const wrapWorkerPort = <T extends Operations>(port: MessagePort) =>
+  Comlink.wrap<WorkerContract<T>>(port);
+
+export const subscriptions = <T extends Operations>(client: T) => {
+  function subscribe<K extends SubscriptionKey<T>>(
+    key: K,
+    ...args: SubscriptionInput<T, K> extends void
+      ? []
+      : [input: SubscriptionInput<T, K>]
+  ) {
+    type U = T[K] extends (
+      onNotification: (
+        notification: ObservableNotification<infer Update>,
+      ) => void,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...args: any[]
+    ) => Promise<() => void>
+      ? Update
+      : never;
+
+    return new Observable<U>((subscriber) => {
+      const subscription = client[key] as unknown as (
+        onNotification: (notification: ObservableNotification<U>) => void,
+        ...args: SubscriptionInput<T, K> extends void
+          ? []
+          : [input: SubscriptionInput<T, K>]
+      ) => Promise<() => void>;
+
+      const notifications$ = new Subject<ObservableNotification<U>>();
+      const sub = notifications$.pipe(dematerialize()).subscribe(subscriber);
+      const onNotification = (n: ObservableNotification<U>) =>
+        notifications$.next(n);
+
+      const unsubscribePromise = subscription(onNotification, ...args);
+
+      return () => {
+        sub.unsubscribe();
+        notifications$.complete();
+        unsubscribePromise.then((f) => f());
+      };
+    });
+  }
+  return subscribe;
+};
 
 export interface CreateClientOptions {
   sharedWorker: SharedWorker;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import * as Comlink from "comlink";
+import type { ObservableNotification, Observable } from "rxjs";
 import type { RegistryContract } from "./contract";
 import {
   subscriptions,
@@ -65,9 +66,11 @@ export const createClient = <T extends Operations>({
     ...args: SubscriptionInput<T, K> extends void
       ? []
       : [input: SubscriptionInput<T, K>]
-  ) => import("rxjs").Observable<
+  ) => Observable<
     T[K] extends (
-      onNext: (value: infer Update) => void,
+      onNotification: (
+        notification: ObservableNotification<infer Update>,
+      ) => void,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...args: any[]
     ) => Promise<() => void>

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,6 +14,14 @@ export interface CreateClientOptions {
   clientId?: string;
 }
 
+/**
+ * Registers a client with the SharedWorker.
+ *
+ * Acquires a `navigator.locks` Web Lock keyed by `clientId` and calls
+ * `registerClient` on the worker through the given port. The lock is held
+ * with an unresolved promise so it persists for the lifetime of the tab,
+ * allowing the worker to detect when the tab closes.
+ */
 const registerClient = async (
   port: MessagePort,
   clientId: string,
@@ -30,6 +38,12 @@ const registerClient = async (
   return registration.promise;
 };
 
+/**
+ * Creates a proxy around the worker that auto-prepends `clientId` to every
+ * method call. Function arguments are wrapped with `Comlink.proxy` so
+ * callbacks (e.g. subscription notification handlers) can cross the
+ * worker boundary.
+ */
 const deriveClient = <T extends Operations>(
   port: MessagePort,
   clientId: string,
@@ -56,6 +70,17 @@ const deriveClient = <T extends Operations>(
   return clientProxy;
 };
 
+/**
+ * Connects to a SharedWorker and returns a typed client proxy paired with a
+ * subscription helper.
+ *
+ * Generates a random `clientId` (or uses the one provided), registers the
+ * client with the worker, and returns a tuple of:
+ * 1. A proxy that forwards every call to the worker with `clientId`
+ *    prepended automatically.
+ * 2. A `subscriptions` function for creating RxJS Observables from the
+ *    worker's subscription-based operations.
+ */
 export const createClient = <T extends Operations>({
   sharedWorker,
   clientId = crypto.randomUUID(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type { WorkerContext, WorkerFactory } from "./worker.ts";
 
 export { createSharedWorkerRuntime } from "./runtime.ts";
 
-export { wrapWorkerPort, subscriptions } from "./model.ts";
+export { wrapWorkerPort, subscriptions } from "./client.ts";
 export type {
   Contract,
   Operation,

--- a/src/model.test-d.ts
+++ b/src/model.test-d.ts
@@ -1,4 +1,5 @@
 import * as Comlink from "comlink";
+import type { ObservableNotification } from "rxjs";
 import { describe, expectTypeOf, test } from "vitest";
 import {
   Contract,
@@ -75,9 +76,7 @@ describe("subscription", () => {
   test("should take an input parameter at the last positional argument", () => {
     type Expected = [
       string,
-      (x: string) => void,
-      (x: unknown) => void,
-      () => void,
+      (notification: ObservableNotification<string>) => void,
       string,
     ];
 
@@ -89,9 +88,7 @@ describe("subscription", () => {
   test("should not take an input parameter at the last positional argument", () => {
     type Expected = [
       string,
-      (x: string) => void,
-      (x: unknown) => void,
-      () => void,
+      (notification: ObservableNotification<string>) => void,
     ];
 
     expectTypeOf(

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,6 @@
 import * as Comlink from "comlink";
-import { Observable } from "rxjs";
+import { Observable, Subject, type ObservableNotification } from "rxjs";
+import { dematerialize } from "rxjs/operators";
 
 /**
  * Type helper that ensures only structured cloneable JavaScript types are allowed.
@@ -71,22 +72,18 @@ export type Operation<
 
 /**
  * Represents a subscription operation that receives real-time updates.
- * Takes callback functions for next, error, and complete events, plus optional input parameters.
- * Returns a Promise of an unsubscribe function.
+ * Takes a single onNotification callback using RxJS ObservableNotification<T>,
+ * plus optional input parameters. Returns a Promise of an unsubscribe function.
  */
 export type Subscription<
   Update extends StructuredCloneable = void,
   Input extends StructuredCloneable = void,
 > = [Input] extends [void]
   ? (
-      onNext: (value: Update) => void,
-      onError: (error: unknown) => void,
-      onComplete: () => void,
+      onNotification: (notification: ObservableNotification<Update>) => void,
     ) => Promise<() => void>
   : (
-      onNext: (value: Update) => void,
-      onError: (error: unknown) => void,
-      onComplete: () => void,
+      onNotification: (notification: ObservableNotification<Update>) => void,
       input: Input,
     ) => Promise<() => void>;
 
@@ -100,16 +97,16 @@ export type Operations = Record<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | ((input: any) => Promise<any>)
   | ((
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onNext: (value: any) => void,
-      onError: (error: unknown) => void,
-      onComplete: () => void,
+      onNotification: (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notification: ObservableNotification<any>,
+      ) => void,
     ) => Promise<() => void>)
   | ((
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onNext: (value: any) => void,
-      onError: (error: unknown) => void,
-      onComplete: () => void,
+      onNotification: (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notification: ObservableNotification<any>,
+      ) => void,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       input: any,
     ) => Promise<() => void>)
@@ -131,27 +128,25 @@ export type Contract<T extends Operations> = T;
  */
 export type WorkerContract<T extends Operations> = {
   [K in keyof T]: T[K] extends (
-    onNext: (value: infer Update) => void,
-    onError: (error: unknown) => void,
-    onComplete: () => void,
+    onNotification: (
+      notification: ObservableNotification<infer Update>,
+    ) => void,
   ) => Promise<() => void>
     ? (
         clientId: string,
-        onNext: (value: Update) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (notification: ObservableNotification<Update>) => void,
       ) => Promise<ProxyMarkedFunction<() => void>>
     : T[K] extends (
-          onNext: (value: infer Update) => void,
-          onError: (error: unknown) => void,
-          onComplete: () => void,
+          onNotification: (
+            notification: ObservableNotification<infer Update>,
+          ) => void,
           input: infer Input,
         ) => Promise<() => void>
       ? (
           clientId: string,
-          onNext: (value: Update) => void,
-          onError: (error: unknown) => void,
-          onComplete: () => void,
+          onNotification: (
+            notification: ObservableNotification<Update>,
+          ) => void,
           input: Input,
         ) => Promise<ProxyMarkedFunction<() => void>>
       : T[K] extends (...args: infer Args) => infer Return
@@ -194,16 +189,16 @@ export const wrapWorkerPort = <T extends Operations>(port: MessagePort) =>
 export type SubscriptionKey<T extends Operations> = {
   [K in keyof T]: T[K] extends
     | ((
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onNext: (value: any) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          notification: ObservableNotification<any>,
+        ) => void,
       ) => Promise<() => void>)
     | ((
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onNext: (value: any) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          notification: ObservableNotification<any>,
+        ) => void,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         input: any,
       ) => Promise<() => void>)
@@ -228,10 +223,10 @@ export type SubscriptionInput<
   T extends Operations,
   K extends SubscriptionKey<T>,
 > = T[K] extends (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onNext: (value: any) => void,
-  onError: (error: unknown) => void,
-  onComplete: () => void,
+  onNotification: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    notification: ObservableNotification<any>,
+  ) => void,
   input: infer Input,
 ) => Promise<() => void>
   ? Input
@@ -245,7 +240,9 @@ export const subscriptions = <T extends Operations>(client: T) => {
       : [input: SubscriptionInput<T, K>]
   ) {
     type U = T[K] extends (
-      onNext: (value: infer Update) => void,
+      onNotification: (
+        notification: ObservableNotification<infer Update>,
+      ) => void,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...args: any[]
     ) => Promise<() => void>
@@ -254,25 +251,24 @@ export const subscriptions = <T extends Operations>(client: T) => {
 
     return new Observable<U>((subscriber) => {
       const subscription = client[key] as unknown as (
-        onNext: (value: U) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (notification: ObservableNotification<U>) => void,
         ...args: SubscriptionInput<T, K> extends void
           ? []
           : [input: SubscriptionInput<T, K>]
       ) => Promise<() => void>;
 
-      const onNext = (value: U) => subscriber.next(value);
-      const onError = (error: unknown) => subscriber.error(error);
-      const onComplete = () => subscriber.complete();
-      const unsubscribePromise = subscription(
-        onNext,
-        onError,
-        onComplete,
-        ...args,
-      );
+      const notifications$ = new Subject<ObservableNotification<U>>();
+      const sub = notifications$.pipe(dematerialize()).subscribe(subscriber);
+      const onNotification = (n: ObservableNotification<U>) =>
+        notifications$.next(n);
 
-      return () => unsubscribePromise.then((f) => f());
+      const unsubscribePromise = subscription(onNotification, ...args);
+
+      return () => {
+        sub.unsubscribe();
+        notifications$.complete();
+        unsubscribePromise.then((f) => f());
+      };
     });
   }
   return subscribe;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,5 @@
-import * as Comlink from "comlink";
-import { Observable, Subject, type ObservableNotification } from "rxjs";
-import { dematerialize } from "rxjs/operators";
+import type * as Comlink from "comlink";
+import type { ObservableNotification } from "rxjs";
 
 /**
  * Type helper that ensures only structured cloneable JavaScript types are allowed.
@@ -164,14 +163,6 @@ export type WorkerProxy<T extends Operations> = Comlink.Remote<
 >;
 
 /**
- * Creates a Comlink remote proxy for the given worker contract using the provided MessagePort.
- * @param port The MessagePort to communicate with the worker.
- * @returns A Comlink remote proxy for the worker contract.
- */
-export const wrapWorkerPort = <T extends Operations>(port: MessagePort) =>
-  Comlink.wrap<WorkerContract<T>>(port);
-
-/**
  * Extracts only the keys from an Operations interface that correspond to Subscription types.
  * This utility type filters out Query and Mutation operations, leaving only subscription keys.
  *
@@ -231,45 +222,3 @@ export type SubscriptionInput<
 ) => Promise<() => void>
   ? Input
   : void;
-
-export const subscriptions = <T extends Operations>(client: T) => {
-  function subscribe<K extends SubscriptionKey<T>>(
-    key: K,
-    ...args: SubscriptionInput<T, K> extends void
-      ? []
-      : [input: SubscriptionInput<T, K>]
-  ) {
-    type U = T[K] extends (
-      onNotification: (
-        notification: ObservableNotification<infer Update>,
-      ) => void,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...args: any[]
-    ) => Promise<() => void>
-      ? Update
-      : never;
-
-    return new Observable<U>((subscriber) => {
-      const subscription = client[key] as unknown as (
-        onNotification: (notification: ObservableNotification<U>) => void,
-        ...args: SubscriptionInput<T, K> extends void
-          ? []
-          : [input: SubscriptionInput<T, K>]
-      ) => Promise<() => void>;
-
-      const notifications$ = new Subject<ObservableNotification<U>>();
-      const sub = notifications$.pipe(dematerialize()).subscribe(subscriber);
-      const onNotification = (n: ObservableNotification<U>) =>
-        notifications$.next(n);
-
-      const unsubscribePromise = subscription(onNotification, ...args);
-
-      return () => {
-        sub.unsubscribe();
-        notifications$.complete();
-        unsubscribePromise.then((f) => f());
-      };
-    });
-  }
-  return subscribe;
-};

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,6 @@
 import * as Comlink from "comlink";
-import { Observable, Subscription } from "rxjs";
+import { Observable, Subscription, type ObservableNotification } from "rxjs";
+import { materialize } from "rxjs/operators";
 import type { RegistryContract } from "./contract";
 import type { Operations, ProxyMarkedFunction, WorkerContract } from "./model";
 
@@ -19,9 +20,7 @@ export type WorkerContext = {
   subscribe: <T>(
     source$: Observable<T>,
     clientId: string,
-    onNext: (value: T) => void,
-    onError: (error: unknown) => void,
-    onComplete: () => void,
+    onNotification: (n: ObservableNotification<T>) => void,
   ) => ProxyMarkedFunction<() => void>;
   clients: ClientRepMap;
 };
@@ -31,9 +30,7 @@ const subscribe =
   <T>(
     source$: Observable<T>,
     clientId: string,
-    onNext: (value: T) => void,
-    onError: (error: unknown) => void,
-    onComplete: () => void,
+    onNotification: (n: ObservableNotification<T>) => void,
   ): ProxyMarkedFunction<() => void> => {
     const client = clients.get(clientId);
 
@@ -41,11 +38,7 @@ const subscribe =
       throw new ReferenceError(`Unknown client ${clientId}`);
     }
 
-    const subscription = source$.subscribe({
-      next: onNext,
-      error: onError,
-      complete: onComplete,
-    });
+    const subscription = source$.pipe(materialize()).subscribe(onNotification);
     client.subscriptions.add(subscription);
 
     return Comlink.proxy(() => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,6 +9,7 @@ interface ClientRep {
   subscriptions: Subscription;
 }
 
+/** Creates a new {@link ClientRep} with an empty subscription container. */
 const createClientRep = (clientId: string): ClientRep => ({
   clientId,
   subscriptions: new Subscription(),
@@ -25,6 +26,17 @@ export type WorkerContext = {
   clients: ClientRepMap;
 };
 
+/**
+ * Creates a `subscribe` function bound to the shared clients map.
+ *
+ * The returned function subscribes to `source$`, materializes notifications,
+ * and forwards them to `onNotification`. The subscription is tracked under
+ * the given client so it is automatically cleaned up when the client
+ * disconnects.
+ *
+ * @returns A Comlink-proxied unsubscribe function the caller can invoke to
+ *          cancel the subscription early.
+ */
 const subscribe =
   (clients: ClientRepMap) =>
   <T>(
@@ -47,6 +59,16 @@ const subscribe =
     });
   };
 
+/**
+ * Creates a reusable worker factory backed by a shared clients map.
+ *
+ * Each call to the returned function invokes `factory` with a
+ * {@link WorkerContext} that shares the same `clients` map and `subscribe`
+ * helper, so multiple factories can cooperate over a single set of clients.
+ *
+ * @param clients - Optional pre-existing clients map. A new map is created
+ *                  when omitted.
+ */
 export const createWorkerFactory =
   (clients: ClientRepMap = new Map()) =>
   <T extends Operations>(
@@ -61,6 +83,14 @@ export type WorkerFactory<T extends Operations> = (
   context: WorkerContext,
 ) => WorkerContract<T>;
 
+/**
+ * Built-in factory that implements the client registry.
+ *
+ * Provides `registerClient`, which adds the client to the shared clients map
+ * and acquires a `navigator.locks` Web Lock keyed by `clientId`. When the
+ * tab closes and the lock is released, all of the client's subscriptions are
+ * unsubscribed and the client is removed from the map.
+ */
 export const registryWorkerFactory: WorkerFactory<RegistryContract> = (
   context,
 ) => {
@@ -86,6 +116,17 @@ export const registryWorkerFactory: WorkerFactory<RegistryContract> = (
   };
 };
 
+/**
+ * Creates a complete SharedWorker object by composing a user-provided factory
+ * with the built-in {@link registryWorkerFactory}.
+ *
+ * Internally calls {@link createWorkerFactory} once to create a single shared
+ * clients map, then invokes both `factory` and `registryWorkerFactory` with
+ * the same {@link WorkerContext}, merging the results into one worker object.
+ *
+ * @param factory - A factory function that receives a {@link WorkerContext}
+ *                  and returns the application-specific worker operations.
+ */
 export const createWorker = <T extends Operations>(
   factory: WorkerFactory<T>,
 ): WorkerContract<T> & WorkerContract<RegistryContract> => {

--- a/tests/integration/rxjs-subscription.test.ts
+++ b/tests/integration/rxjs-subscription.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import type { ObservableNotification } from "rxjs";
 
 describe("RxJS Subscription Lifecycle", () => {
   beforeAll(async () => {
@@ -19,18 +20,16 @@ describe("RxJS Subscription Lifecycle", () => {
 
     type TestContract = {
       testSubscription: (
-        onNext: (value: string) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (notification: ObservableNotification<string>) => void,
       ) => Promise<() => void>;
     };
 
     const mockClient: TestContract = {
-      testSubscription: async (onNext, _onError, onComplete) => {
+      testSubscription: async (onNotification) => {
         setTimeout(() => {
-          onNext("test-value-1");
-          onNext("test-value-2");
-          onComplete();
+          onNotification({ kind: "N", value: "test-value-1" });
+          onNotification({ kind: "N", value: "test-value-2" });
+          onNotification({ kind: "C" });
         }, 0);
 
         return () => {};
@@ -61,16 +60,14 @@ describe("RxJS Subscription Lifecycle", () => {
 
     type TestContract = {
       errorSubscription: (
-        onNext: (value: string) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (notification: ObservableNotification<string>) => void,
       ) => Promise<() => void>;
     };
 
     const mockClient: TestContract = {
-      errorSubscription: async (_onNext, onError, _onComplete) => {
+      errorSubscription: async (onNotification) => {
         setTimeout(() => {
-          onError(new Error("test-error"));
+          onNotification({ kind: "E", error: new Error("test-error") });
         }, 0);
 
         return () => {};
@@ -105,16 +102,14 @@ describe("RxJS Subscription Lifecycle", () => {
 
     type TestContract = {
       longSubscription: (
-        onNext: (value: number) => void,
-        onError: (error: unknown) => void,
-        onComplete: () => void,
+        onNotification: (notification: ObservableNotification<number>) => void,
       ) => Promise<() => void>;
     };
 
     const mockClient: TestContract = {
-      longSubscription: async (onNext, _onError, _onComplete) => {
+      longSubscription: async (onNotification) => {
         const interval = setInterval(() => {
-          onNext(Date.now());
+          onNotification({ kind: "N", value: Date.now() });
         }, 10);
 
         return () => {


### PR DESCRIPTION
## Summary

- Replace subscription callbacks with materialized observables. Subscriptions now use a single `onNotification` callback receiving RxJS `ObservableNotification<T>` instead of separate `onNext`, `onError`, and `onComplete` callbacks. This is a breaking change for custom `WorkerFactory` implementations that use the `subscribe` helper from `WorkerContext`.
- Move `wrapWorkerPort` and `subscriptions` runtime functions from `model.ts` to `client.ts`, making `model.ts` a types-only module.
- Add JSDoc comments and internals documentation across library source files.
- Add changesets for pending `Operation` type refactor and materialized subscriptions.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` builds successfully
- [x] `npm test` — type-level tests pass
- [x] Smoke test Echo example (single tab + multi-tab)
- [x] Smoke test User Profile example (single tab + multi-tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)